### PR TITLE
Update @actions/core to 1.10.0

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -19,7 +19,13 @@ module.exports =
 /******/ 		};
 /******/
 /******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/ 		var threw = true;
+/******/ 		try {
+/******/ 			modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/ 			threw = false;
+/******/ 		} finally {
+/******/ 			if(threw) delete installedModules[moduleId];
+/******/ 		}
 /******/
 /******/ 		// Flag the module as loaded
 /******/ 		module.l = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "tool-versions-action",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.9.1"
+        "@actions/core": "^1.10.0"
       },
       "devDependencies": {
         "@zeit/ncc": "^0.22.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/actions/javascript-action#readme",
   "dependencies": {
-    "@actions/core": "^1.9.1"
+    "@actions/core": "^1.10.0"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.22.3",


### PR DESCRIPTION
The `save-state` and `set-output` commands are getting deprecated, and the latest version of the @actions/core updates the `saveState` and `setOutput` functions so they work without any warnings.

More info: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

this is reopen of #20